### PR TITLE
fix: Enable system ACLs

### DIFF
--- a/1908.patch.txt
+++ b/1908.patch.txt
@@ -1,26 +1,50 @@
-From c10b8eec7976fe2007e800f7a1400f212f0cf239 Mon Sep 17 00:00:00 2001
+From 30a13da6d8850e8515399e7c5bb7bbbd65e71efc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Wed, 18 Nov 2020 17:20:15 +0100
-Subject: [PATCH 01/10] s3-modules: add get_xattr_acl_name() helper, defaults
+Subject: [PATCH 01/13] s3-modules: add get_xattr_acl_name() helper, defaults
  to security.NTACL
 
 Guenther
 
 Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
- source3/modules/vfs_acl_common.c | 8 ++++++++
- source3/modules/vfs_acl_common.h | 2 +-
- 2 files changed, 9 insertions(+), 1 deletion(-)
+ source3/modules/vfs_acl_xattr_common.c | 31 ++++++++++++++++++++++++++
+ source3/modules/vfs_acl_xattr_common.h | 22 ++++++++++++++++++
+ source3/modules/wscript_build          |  6 ++++-
+ 3 files changed, 58 insertions(+), 1 deletion(-)
+ create mode 100644 source3/modules/vfs_acl_xattr_common.c
+ create mode 100644 source3/modules/vfs_acl_xattr_common.h
 
-diff --git a/source3/modules/vfs_acl_common.c b/source3/modules/vfs_acl_common.c
-index 81e1116b20b..b0c98bf5ab9 100644
---- a/source3/modules/vfs_acl_common.c
-+++ b/source3/modules/vfs_acl_common.c
-@@ -1180,3 +1180,11 @@ int fchmod_acl_module_common(struct vfs_handle_struct *handle,
- 	}
- 	return 0;
- }
+diff --git a/source3/modules/vfs_acl_xattr_common.c b/source3/modules/vfs_acl_xattr_common.c
+new file mode 100644
+index 00000000000..fe0b60b20f8
+--- /dev/null
++++ b/source3/modules/vfs_acl_xattr_common.c
+@@ -0,0 +1,31 @@
++/*
++ * Store Windows ACLs in data store - common functions.
++ *
++ * Copyright (C) Volker Lendecke, 2008
++ * Copyright (C) Jeremy Allison, 2009
++ * Copyright (C) Ralph Böhme, 2016
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, see <http://www.gnu.org/licenses/>.
++ */
 +
++#include "includes.h"
++#include "librpc/gen_ndr/ndr_xattr.h"
++#include "vfs_acl_xattr_common.h"
 +
 +const char *get_xattr_acl_name(int service)
 +{
@@ -28,48 +52,157 @@ index 81e1116b20b..b0c98bf5ab9 100644
 +				    "xattr", "unprotected_ntacl_name",
 +				    XATTR_NTACL_NAME);
 +}
-diff --git a/source3/modules/vfs_acl_common.h b/source3/modules/vfs_acl_common.h
-index c4b4fb9c1b3..745ede61b80 100644
---- a/source3/modules/vfs_acl_common.h
-+++ b/source3/modules/vfs_acl_common.h
-@@ -85,6 +85,6 @@ NTSTATUS fset_nt_acl_common(
-         uint32_t security_info_sent,
- 	const struct security_descriptor *orig_psd);
- 
--
+diff --git a/source3/modules/vfs_acl_xattr_common.h b/source3/modules/vfs_acl_xattr_common.h
+new file mode 100644
+index 00000000000..eb314c2fd60
+--- /dev/null
++++ b/source3/modules/vfs_acl_xattr_common.h
+@@ -0,0 +1,22 @@
++/*
++ * Store Windows ACLs in data store - common functions.
++ *
++ * Copyright (C) Volker Lendecke, 2008
++ * Copyright (C) Jeremy Allison, 2009
++ * Copyright (C) Ralph Böhme, 2016
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, see <http://www.gnu.org/licenses/>.
++ */
++
 +const char *get_xattr_acl_name(int service);
+diff --git a/source3/modules/wscript_build b/source3/modules/wscript_build
+index 40df4539392..e4fccd0cb61 100644
+--- a/source3/modules/wscript_build
++++ b/source3/modules/wscript_build
+@@ -11,7 +11,11 @@ bld.SAMBA3_BINARY('test_nfs4_acls',
  
- #endif
+ bld.SAMBA3_SUBSYSTEM('vfs_acl_common',
+                      source='vfs_acl_common.c',
+-                     deps='gnutls')
++                     deps='gnutls vfs_acl_xattr_common')
++
++bld.SAMBA3_SUBSYSTEM('vfs_acl_xattr_common',
++                     source='vfs_acl_xattr_common.c',
++                     deps='')
+ 
+ bld.SAMBA3_SUBSYSTEM('POSIXACL_XATTR',
+                  source='posixacl_xattr.c',
 -- 
 GitLab
 
 
-From cc97d569eff0024eb24393de48d3d5ef2f8b73d3 Mon Sep 17 00:00:00 2001
+From ec0e89d7ef73e8d6bb27699614c1e1866ead0bb6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
-Date: Wed, 18 Nov 2020 17:21:38 +0100
-Subject: [PATCH 02/10] s3-modules: use get_xattr_acl_name() in acl_xattr vfs
- module
+Date: Wed, 29 Sep 2021 16:48:35 +0200
+Subject: [PATCH 02/13] s3-modules: store xattr ntacl value in common
+ acl_config
 
 Guenther
 
 Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
- source3/modules/vfs_acl_xattr.c | 11 +++++++----
- 1 file changed, 7 insertions(+), 4 deletions(-)
+ source3/modules/vfs_acl_common.c | 2 ++
+ source3/modules/vfs_acl_common.h | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/source3/modules/vfs_acl_common.c b/source3/modules/vfs_acl_common.c
+index 81e1116b20b..5f13e22409d 100644
+--- a/source3/modules/vfs_acl_common.c
++++ b/source3/modules/vfs_acl_common.c
+@@ -29,6 +29,7 @@
+ #include "../librpc/gen_ndr/ndr_security.h"
+ #include "../lib/util/bitmap.h"
+ #include "passdb/lookup_sid.h"
++#include "vfs_acl_xattr_common.h"
+ 
+ #include <gnutls/gnutls.h>
+ #include <gnutls/crypto.h>
+@@ -67,6 +68,7 @@ bool init_acl_common_config(vfs_handle_struct *handle,
+ 						 "default acl style",
+ 						 default_acl_style_list,
+ 						 DEFAULT_ACL_POSIX);
++	config->xattr_ntacl_name = get_xattr_acl_name(SNUM(handle->conn));
+ 
+ 	SMB_VFS_HANDLE_SET_DATA(handle, config, NULL,
+ 				struct acl_common_config,
+diff --git a/source3/modules/vfs_acl_common.h b/source3/modules/vfs_acl_common.h
+index c4b4fb9c1b3..0b91ec9cadf 100644
+--- a/source3/modules/vfs_acl_common.h
++++ b/source3/modules/vfs_acl_common.h
+@@ -27,6 +27,7 @@
+ struct acl_common_config {
+ 	bool ignore_system_acls;
+ 	enum default_acl_style default_acl_style;
++	const char *xattr_ntacl_name;
+ };
+ 
+ struct acl_common_fsp_ext {
+-- 
+GitLab
+
+
+From 73d4a007e465d5340d45215ad78189cbb6cb4b5f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
+Date: Wed, 18 Nov 2020 17:21:38 +0100
+Subject: [PATCH 03/13] s3-modules: add and use get_xattr_acl_name_from_config
+ wrapper acl_xattr vfs module
+
+Guenther
+
+Signed-off-by: Guenther Deschner <gd@samba.org>
+---
+ source3/modules/vfs_acl_xattr.c | 38 ++++++++++++++++++++++++++++-----
+ 1 file changed, 33 insertions(+), 5 deletions(-)
 
 diff --git a/source3/modules/vfs_acl_xattr.c b/source3/modules/vfs_acl_xattr.c
-index ad11e20b7dc..c2cfa7d0c1b 100644
+index ad11e20b7dc..f2c3c697325 100644
 --- a/source3/modules/vfs_acl_xattr.c
 +++ b/source3/modules/vfs_acl_xattr.c
-@@ -67,6 +67,7 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
+@@ -58,6 +58,17 @@ static ssize_t getxattr_do(vfs_handle_struct *handle,
+ 	return sizeret;
+ }
+ 
++static const char *get_xattr_acl_name_from_config(vfs_handle_struct *handle)
++{
++	struct acl_common_config *config = NULL;
++
++	SMB_VFS_HANDLE_GET_DATA(handle, config,
++				struct acl_common_config,
++				return NULL);
++
++	return config->xattr_ntacl_name;
++}
++
+ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
+ 			vfs_handle_struct *handle,
+ 			files_struct *fsp,
+@@ -67,9 +78,14 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
  	uint8_t *val = NULL;
  	uint8_t *tmp;
  	ssize_t sizeret;
-+	const char *xattr_name = get_xattr_acl_name(SNUM(handle->conn));
++	const char *xattr_name;
  
- 	ZERO_STRUCTP(pblob);
+-	ZERO_STRUCTP(pblob);
++	xattr_name = get_xattr_acl_name_from_config(handle);
++	if (xattr_name == NULL) {
++		return NT_STATUS_NO_MEMORY;
++	}
  
-@@ -80,7 +81,7 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
++	ZERO_STRUCTP(pblob);
+   again:
+ 
+ 	tmp = talloc_realloc(ctx, val, uint8_t, size);
+@@ -80,7 +96,7 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
  	val = tmp;
  
  	sizeret =
@@ -78,7 +211,7 @@ index ad11e20b7dc..c2cfa7d0c1b 100644
  
  	if (sizeret >= 0) {
  		pblob->data = val;
-@@ -94,7 +95,7 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
+@@ -94,7 +110,7 @@ static NTSTATUS fget_acl_blob(TALLOC_CTX *ctx,
  
  	/* Too small, try again. */
  	sizeret =
@@ -87,11 +220,16 @@ index ad11e20b7dc..c2cfa7d0c1b 100644
  	if (sizeret < 0) {
  		goto err;
  	}
-@@ -126,12 +127,13 @@ static NTSTATUS store_acl_blob_fsp(vfs_handle_struct *handle,
+@@ -126,12 +142,18 @@ static NTSTATUS store_acl_blob_fsp(vfs_handle_struct *handle,
  {
  	int ret;
  	int saved_errno = 0;
-+	const char *xattr_name = get_xattr_acl_name(SNUM(handle->conn));
++	const char *xattr_name;
++
++	xattr_name = get_xattr_acl_name_from_config(handle);
++	if (xattr_name == NULL) {
++		return NT_STATUS_NO_MEMORY;
++	}
  
  	DEBUG(10,("store_acl_blob_fsp: storing blob length %u on file %s\n",
  		  (unsigned int)pblob->length, fsp_str_dbg(fsp)));
@@ -102,15 +240,20 @@ index ad11e20b7dc..c2cfa7d0c1b 100644
  			pblob->data, pblob->length, 0);
  	if (ret) {
  		saved_errno = errno;
-@@ -160,6 +162,7 @@ static int sys_acl_set_fd_xattr(vfs_handle_struct *handle,
+@@ -160,6 +182,12 @@ static int sys_acl_set_fd_xattr(vfs_handle_struct *handle,
  	struct acl_common_fsp_ext *ext = (struct acl_common_fsp_ext *)
  		VFS_FETCH_FSP_EXTENSION(handle, fsp);
  	int ret;
-+	const char *xattr_name = get_xattr_acl_name(SNUM(handle->conn));
++	const char *xattr_name;
++
++	xattr_name = get_xattr_acl_name_from_config(handle);
++	if (xattr_name == NULL) {
++		return -1;
++	}
  
  	ret = SMB_VFS_NEXT_SYS_ACL_SET_FD(handle,
  					  fsp,
-@@ -174,7 +177,7 @@ static int sys_acl_set_fd_xattr(vfs_handle_struct *handle,
+@@ -174,7 +202,7 @@ static int sys_acl_set_fd_xattr(vfs_handle_struct *handle,
  	}
  
  	become_root();
@@ -123,19 +266,34 @@ index ad11e20b7dc..c2cfa7d0c1b 100644
 GitLab
 
 
-From ae1c63ed11d40342200bb232ce6a0c897be2e682 Mon Sep 17 00:00:00 2001
+From 10773a601a0e902c52d9e12eec97476bca9001db Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Thu, 9 Sep 2021 16:11:33 +0200
-Subject: [PATCH 03/10] s3-smbd: pass down service to samba_private_attr_name()
+Subject: [PATCH 04/13] s3-smbd: pass down service to samba_private_attr_name()
 
 Guenther
 
 Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
- source3/smbd/proto.h  | 3 ++-
- source3/smbd/trans2.c | 3 ++-
- 2 files changed, 4 insertions(+), 2 deletions(-)
+ source3/modules/vfs_streams_xattr.c | 3 ++-
+ source3/smbd/proto.h                | 3 ++-
+ source3/smbd/trans2.c               | 7 ++++---
+ 3 files changed, 8 insertions(+), 5 deletions(-)
 
+diff --git a/source3/modules/vfs_streams_xattr.c b/source3/modules/vfs_streams_xattr.c
+index 76b23c7224f..c0d9f30ddec 100644
+--- a/source3/modules/vfs_streams_xattr.c
++++ b/source3/modules/vfs_streams_xattr.c
+@@ -723,7 +723,8 @@ static NTSTATUS walk_xattr_streams(vfs_handle_struct *handle,
+ 		 */
+ 		if (strncasecmp_m(names[i], SAMBA_XATTR_DOSSTREAM_PREFIX,
+ 				  strlen(SAMBA_XATTR_DOSSTREAM_PREFIX)) != 0) {
+-			if (samba_private_attr_name(names[i])) {
++			if (samba_private_attr_name(names[i],
++						    SNUM(handle->conn))) {
+ 				continue;
+ 			}
+ 		}
 diff --git a/source3/smbd/proto.h b/source3/smbd/proto.h
 index bf7401f5191..9717e51f3a2 100644
 --- a/source3/smbd/proto.h
@@ -151,7 +309,7 @@ index bf7401f5191..9717e51f3a2 100644
  			  files_struct *fsp,
  			  const char *ea_name,
 diff --git a/source3/smbd/trans2.c b/source3/smbd/trans2.c
-index a6bd232f679..8cf94cc1611 100644
+index cd6b61429c5..0fcaa933d1d 100644
 --- a/source3/smbd/trans2.c
 +++ b/source3/smbd/trans2.c
 @@ -195,7 +195,8 @@ uint64_t smb_roundup(connection_struct *conn, uint64_t val)
@@ -164,47 +322,50 @@ index a6bd232f679..8cf94cc1611 100644
  {
  	static const char * const prohibited_ea_names[] = {
  		SAMBA_POSIX_INHERITANCE_EA_NAME,
+@@ -448,7 +449,7 @@ static NTSTATUS get_ea_list_from_fsp(TALLOC_CTX *mem_ctx,
+ 		fstring dos_ea_name;
+ 
+ 		if (strnequal(names[i], "system.", 7)
+-		    || samba_private_attr_name(names[i]))
++		    || samba_private_attr_name(names[i], SNUM(fsp->conn)))
+ 			continue;
+ 
+ 		/*
+@@ -782,7 +783,7 @@ NTSTATUS set_ea(connection_struct *conn, files_struct *fsp,
+ 
+ 		DEBUG(10,("set_ea: ea_name %s ealen = %u\n", unix_ea_name, (unsigned int)ea_list->ea.value.length));
+ 
+-		if (samba_private_attr_name(unix_ea_name)) {
++		if (samba_private_attr_name(unix_ea_name, SNUM(conn))) {
+ 			DEBUG(10,("set_ea: ea name %s is a private Samba name.\n", unix_ea_name));
+ 			return NT_STATUS_ACCESS_DENIED;
+ 		}
 -- 
 GitLab
 
 
-From ae93afe2e140c8af992df8df90f8bef0a0775fb2 Mon Sep 17 00:00:00 2001
+From 5ee620cae67a32b59e7e64b11913e42afad6d344 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Wed, 18 Nov 2020 17:24:50 +0100
-Subject: [PATCH 04/10] s3-smbd: use get_xattr_acl_name() in
+Subject: [PATCH 05/13] s3-smbd: use get_xattr_acl_name() in
  samba_private_attr_name()
 
 Guenther
 
 Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
- source3/modules/vfs_streams_xattr.c |  3 ++-
- source3/smbd/trans2.c               | 12 ++++++++----
- 2 files changed, 10 insertions(+), 5 deletions(-)
+ source3/smbd/trans2.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
 
-diff --git a/source3/modules/vfs_streams_xattr.c b/source3/modules/vfs_streams_xattr.c
-index 558bf228794..71d572298b8 100644
---- a/source3/modules/vfs_streams_xattr.c
-+++ b/source3/modules/vfs_streams_xattr.c
-@@ -723,7 +723,8 @@ static NTSTATUS walk_xattr_streams(vfs_handle_struct *handle,
- 		 */
- 		if (strncasecmp_m(names[i], SAMBA_XATTR_DOSSTREAM_PREFIX,
- 				  strlen(SAMBA_XATTR_DOSSTREAM_PREFIX)) != 0) {
--			if (samba_private_attr_name(names[i])) {
-+			if (samba_private_attr_name(names[i],
-+						    SNUM(handle->conn))) {
- 				continue;
- 			}
- 		}
 diff --git a/source3/smbd/trans2.c b/source3/smbd/trans2.c
-index 8cf94cc1611..5569e77aea6 100644
+index 0fcaa933d1d..41adc2de2b4 100644
 --- a/source3/smbd/trans2.c
 +++ b/source3/smbd/trans2.c
 @@ -45,6 +45,7 @@
  #include "smb1_utils.h"
  #include "libcli/smb/smb2_posix.h"
  #include "lib/util/string_wrappers.h"
-+#include "modules/vfs_acl_common.h"
++#include "vfs_acl_xattr_common.h"
  
  #define DIR_ENTRY_SAFETY_MARGIN 4096
  
@@ -226,32 +387,14 @@ index 8cf94cc1611..5569e77aea6 100644
  	for (i = 0; prohibited_ea_names[i]; i++) {
  		if (strequal( prohibited_ea_names[i], unix_ea_name))
  			return true;
-@@ -449,7 +453,7 @@ static NTSTATUS get_ea_list_from_fsp(TALLOC_CTX *mem_ctx,
- 		fstring dos_ea_name;
- 
- 		if (strnequal(names[i], "system.", 7)
--		    || samba_private_attr_name(names[i]))
-+		    || samba_private_attr_name(names[i], SNUM(fsp->conn)))
- 			continue;
- 
- 		/*
-@@ -782,7 +786,7 @@ NTSTATUS set_ea(connection_struct *conn, files_struct *fsp,
- 
- 		DEBUG(10,("set_ea: ea_name %s ealen = %u\n", unix_ea_name, (unsigned int)ea_list->ea.value.length));
- 
--		if (samba_private_attr_name(unix_ea_name)) {
-+		if (samba_private_attr_name(unix_ea_name, SNUM(conn))) {
- 			DEBUG(10,("set_ea: ea name %s is a private Samba name.\n", unix_ea_name));
- 			return NT_STATUS_ACCESS_DENIED;
- 		}
 -- 
 GitLab
 
 
-From eb519a4fe1b0d9529e02b4b929e801d602476629 Mon Sep 17 00:00:00 2001
+From f09560fb7d7cd288d8c0597ba32aa993dcf1cdb2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Wed, 18 Nov 2020 18:19:00 +0100
-Subject: [PATCH 05/10] s4-ntvfs: add xattr_ntacl_name()
+Subject: [PATCH 06/13] s4-ntvfs: add xattr_ntacl_name()
 
 Guenther
 
@@ -259,8 +402,8 @@ Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
  source4/ntvfs/posix/wscript_build |  2 +-
  source4/ntvfs/posix/xattr_util.c  | 37 +++++++++++++++++++++++++++++++
- source4/ntvfs/posix/xattr_util.h  |  1 +
- 3 files changed, 39 insertions(+), 1 deletion(-)
+ source4/ntvfs/posix/xattr_util.h  | 22 ++++++++++++++++++
+ 3 files changed, 60 insertions(+), 1 deletion(-)
  create mode 100644 source4/ntvfs/posix/xattr_util.c
  create mode 100644 source4/ntvfs/posix/xattr_util.h
 
@@ -322,19 +465,40 @@ index 00000000000..e0986425a2b
 +}
 diff --git a/source4/ntvfs/posix/xattr_util.h b/source4/ntvfs/posix/xattr_util.h
 new file mode 100644
-index 00000000000..dc9e88b5866
+index 00000000000..cb4bc0e4ea5
 --- /dev/null
 +++ b/source4/ntvfs/posix/xattr_util.h
-@@ -0,0 +1 @@
+@@ -0,0 +1,22 @@
++/*
++   Unix SMB/CIFS implementation.
++
++   POSIX NTVFS backend - NT ACLs in xattrs
++
++   Copyright (C) Andrew Tridgell 2006
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.
++*/
++
 +const char *xattr_ntacl_name(struct loadparm_context *lp_ctx);
 -- 
 GitLab
 
 
-From f2533398988d3b0309e1c26afd92483e3d20a5e5 Mon Sep 17 00:00:00 2001
+From 21ced8e03867f24c630f7c26cd565515a4c444a3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Wed, 18 Nov 2020 18:25:31 +0100
-Subject: [PATCH 06/10] s4-ntvfs: use xattr_ntacl_name() in pvfs_acl_xattr
+Subject: [PATCH 07/13] s4-ntvfs: use xattr_ntacl_name() in pvfs_acl_xattr
  module
 
 Guenther
@@ -399,10 +563,10 @@ index 1f569ca43f3..293c47f7f12 100644
 GitLab
 
 
-From f9df748363891dffa2efae639f5c65b0263e7610 Mon Sep 17 00:00:00 2001
+From 722cf91ff21b8f307467d820d752297d15f957d9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Wed, 18 Nov 2020 18:26:43 +0100
-Subject: [PATCH 07/10] s4-ntvfs: use xattr_ntacl_name() in pvfs_xattr module
+Subject: [PATCH 08/13] s4-ntvfs: use xattr_ntacl_name() in pvfs_xattr module
 
 Guenther
 
@@ -462,10 +626,10 @@ index ab88d89d10b..b65cf45ff6a 100644
 GitLab
 
 
-From e263aebcd68c8955cc5660732d3a13f8c16a6912 Mon Sep 17 00:00:00 2001
+From 7b2de9f123bd206555ac743f3a7885eb21bf15ad Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Thu, 9 Sep 2021 15:14:23 +0200
-Subject: [PATCH 08/10] python: query parametric ntacls option for the xattr
+Subject: [PATCH 09/13] python: query parametric ntacls option for the xattr
  name
 
 Guenther
@@ -541,10 +705,10 @@ index 89e64b7dc5a..338a87ade36 100644
 GitLab
 
 
-From b125fd9460ca89d6bd9407515f8882d5b106d39d Mon Sep 17 00:00:00 2001
+From 6f4aac74c1a50242a18f83e0102e051a5749a19b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Thu, 9 Sep 2021 15:39:32 +0200
-Subject: [PATCH 09/10] python: pass down xattr names to copytree_with_xattrs()
+Subject: [PATCH 10/13] python: pass down xattr names to copytree_with_xattrs()
  in xattr module
 
 Guenther
@@ -601,25 +765,25 @@ index 19eb67ab315..4098e0a5c98 100644
 GitLab
 
 
-From b2dea0e1e3ba157c53a3a44f0ca6f54697358fd0 Mon Sep 17 00:00:00 2001
+From 48e2f15741ff1ca5fd1f90e6132b92c8ae09b475 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
 Date: Thu, 9 Sep 2021 16:42:30 +0200
-Subject: [PATCH 10/10] docs: document xattr:unprotected_ntacl_name
+Subject: [PATCH 11/13] docs: document xattr:unprotected_ntacl_name
 
 Guenther
 
 Signed-off-by: Guenther Deschner <gd@samba.org>
 ---
- .../filename/xattrunprotectedntaclname.xml    | 23 +++++++++++++++++++
- 1 file changed, 23 insertions(+)
+ .../filename/xattrunprotectedntaclname.xml    | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
  create mode 100644 docs-xml/smbdotconf/filename/xattrunprotectedntaclname.xml
 
 diff --git a/docs-xml/smbdotconf/filename/xattrunprotectedntaclname.xml b/docs-xml/smbdotconf/filename/xattrunprotectedntaclname.xml
 new file mode 100644
-index 00000000000..730bd0f3b31
+index 00000000000..075c2bd3631
 --- /dev/null
 +++ b/docs-xml/smbdotconf/filename/xattrunprotectedntaclname.xml
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,24 @@
 +<samba:parameter name="xattr:unprotected_ntacl_name"
 +                 context="S"
 +                 type="string"
@@ -642,7 +806,98 @@ index 00000000000..730bd0f3b31
 +
 +</description>
 +<value type="default">security.NTACL</value>
++<value type="example">user.NTACL</value>
 +</samba:parameter>
+-- 
+GitLab
+
+
+From 72252efa1dbc189a92b59200159dfabcd2c9fe86 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
+Date: Mon, 1 Nov 2021 09:50:10 +0100
+Subject: [PATCH 12/13] s3-memcache: add new memcache type XATTR_NAME_CACHE
+
+Guenther
+
+Signed-off-by: Guenther Deschner <gd@samba.org>
+---
+ lib/util/memcache.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/util/memcache.h b/lib/util/memcache.h
+index 4331c2f1465..926aa0a7312 100644
+--- a/lib/util/memcache.h
++++ b/lib/util/memcache.h
+@@ -47,6 +47,7 @@ enum memcache_number {
+ 	SHARE_MODE_LOCK_CACHE,	/* talloc */
+ 	VIRUSFILTER_SCAN_RESULTS_CACHE_TALLOC, /* talloc */
+ 	DFREE_CACHE,
++	XATTR_NAME_CACHE
+ };
+ 
+ /*
+-- 
+GitLab
+
+
+From 82a3bd9233512976c9bf574409bc820087b5d882 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?G=C3=BCnther=20Deschner?= <gd@samba.org>
+Date: Mon, 1 Nov 2021 09:52:00 +0100
+Subject: [PATCH 13/13] s3-smbd: use memcache store of acl_xattr_name in
+ samba_private_attr_name()
+
+Guenther
+
+Signed-off-by: Guenther Deschner <gd@samba.org>
+---
+ source3/smbd/trans2.c | 25 +++++++++++++++++++++++--
+ 1 file changed, 23 insertions(+), 2 deletions(-)
+
+diff --git a/source3/smbd/trans2.c b/source3/smbd/trans2.c
+index 41adc2de2b4..0edd86fbe0d 100644
+--- a/source3/smbd/trans2.c
++++ b/source3/smbd/trans2.c
+@@ -46,6 +46,7 @@
+ #include "libcli/smb/smb2_posix.h"
+ #include "lib/util/string_wrappers.h"
+ #include "vfs_acl_xattr_common.h"
++#include "lib/util/memcache.h"
+ 
+ #define DIR_ENTRY_SAFETY_MARGIN 4096
+ 
+@@ -205,10 +206,30 @@ bool samba_private_attr_name(const char *unix_ea_name,
+ 		SAMBA_XATTR_MARKER,
+ 		NULL
+ 	};
+-	const char *xattr_name = get_xattr_acl_name(service);
+ 	int i;
++	bool ok;
++	DATA_BLOB k, v;
++	const char *config_xattr_acl_name = NULL;
++
++	k = data_blob_string_const("xattr_ntacl_name");
++
++	ok = memcache_lookup(smbd_memcache(), XATTR_NAME_CACHE, k, &v);
++	if (ok) {
++		config_xattr_acl_name = (const char *)v.data;
++	} else {
++		config_xattr_acl_name = get_xattr_acl_name(service);
++		if (config_xattr_acl_name == NULL) {
++			return false;
++		}
++
++		v = data_blob_string_const_null(config_xattr_acl_name);
++
++		memcache_add(smbd_memcache(),
++			     XATTR_NAME_CACHE,
++			     k, v);
++	}
+ 
+-	if (strequal(xattr_name, unix_ea_name)) {
++	if (strequal(unix_ea_name, config_xattr_acl_name)) {
+ 		return true;
+ 	}
+ 
 -- 
 GitLab
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,13 +101,13 @@ RUN apt-get -y update && \
     xsltproc \
     zlib1g-dev
 
-COPY samba-4.15.0.tar.gz /samba-4.15.0.tar.gz
+COPY samba-4.15.2.tar.gz /samba-4.15.2.tar.gz
 
 COPY 1908.patch.txt /tmp/patch.txt
 
-RUN tar -zxf samba-4.15.0.tar.gz
+RUN tar -zxf samba-4.15.2.tar.gz
 
-WORKDIR /samba-4.15.0
+WORKDIR /samba-4.15.2
 
 RUN patch -p 1 < /tmp/patch.txt
 
@@ -123,7 +123,7 @@ ENV PATH=/usr/local/samba/bin/:/usr/local/samba/sbin/:$PATH
 
 WORKDIR /
 
-RUN rm -rf /samba-4.15.0
+RUN rm -rf /samba-4.15.2
 
 RUN mv -v /usr/local/samba/lib/libnss_win{s,bind}.so.*  /lib
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,7 +123,7 @@ done
 
 echo "" >> /usr/local/samba/etc/smb.conf
 
-net ads join -U"${AD_USERNAME}"%"${AD_PASSWORD}"
+net ads join -U"${AD_USERNAME}"%"${AD_PASSWORD}" || exit 1
 
 smbd -D
 nmbd -D

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,8 @@ cat > /usr/local/samba/etc/smb.conf << EOL
     winbind refresh tickets = Yes
     winbind offline logon = yes
     winbind normalize names = Yes
+    winbind enum users = yes
+    winbind enum groups = yes
 
     ## map ids outside of domain to tdb files.
     idmap config *:backend = tdb
@@ -72,8 +74,8 @@ cat > /usr/local/samba/etc/smb.conf << EOL
     # For ACL support on domain member
     vfs objects = acl_xattr
     map acl inherit = Yes
-    #store dos attributes = Yes
-    acl_xattr:ignore system acls = yes
+    store dos attributes = Yes
+    acl_xattr:ignore system acls = no
     xattr:unprotected_ntacl_name = user.NTACL
 
     # Share Setting Globally

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -131,7 +131,7 @@ winbindd -D
 
 until getent passwd "${DOMAINNAME}\\${AD_USERNAME}"; do sleep 1; done
 
-net ads dns register -U"${AD_USERNAME}"%"${AD_PASSWORD}"
+net ads dns register -U"${AD_USERNAME}"%"${AD_PASSWORD}" || exit 1
 
 for var in ${!SHARE@};
 do


### PR DESCRIPTION
This PR: 

- Updates the [patch](https://gitlab.com/samba-team/samba/-/merge_requests/1908) used to allow Samba to run in containers 
- Updates Samba source to latest 4.15.2
- Exits w/ `Error`/`CrashLoopBackOff` when domain join or DNS registration fails
- Disables `ignore system acls`
-- Fixes non Domain Admin group ACLs working on Windows
-- Allows interoperability with POSIX ACLs