### PR TITLE
Remove use of vfs_fruit module

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,12 +98,6 @@ cat > /usr/local/samba/etc/smb.conf << EOL
     server max protocol = SMB3
     server min protocol = SMB2_10
 
-    # Time Machine
-    fruit:delete_empty_adfiles = yes
-    fruit:time machine = yes
-    fruit:veto_appledouble = no
-    fruit:wipe_intentionally_left_blank_rfork = yes
-
     #SMB Multichannel
     server multi channel support = yes
     aio read size = 1


### PR DESCRIPTION
Mitigates https://www.samba.org/samba/security/CVE-2021-44142.html

Upgrading to 4.15.2 which patches the [vfs_fruit module](https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html) conflicts with the vfs patch for container compatibility

`vfs_fruit` provides "nice to have" improvements for macOS only, so safe to remove at this time