### PR TITLE
refactor: Use multi-stage Docker build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,35 +1,114 @@
-image: docker:stable
+# following instructions in https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
+# kaniko docs: https://github.com/GoogleContainerTools/kaniko
+default:
+  image:
+    name: gcr.io/kaniko-project/executor:v1.8.1-debug
+    entrypoint: [""]
+  tags:
+    - ord1-tenant
+
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "push" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline"'
+
+variables:
+  # kaniko caching docs: https://cloud.google.com/build/docs/kaniko-cache
+  # KANIKO_CACHE_HOST: "kaniko-cache-docker-registry.kaniko.svc"
+  # KANIKO_CACHE_PORT: "5000"
+  # KANIKO_CACHE_PROXY: "http://193.25.126.17:3128"
+
+  KANIKO_CACHE_REGISTRY: "${KANIKO_CACHE_HOST}:${KANIKO_CACHE_PORT}"
+  KANIKO_CACHE_REPO: "${KANIKO_CACHE_REGISTRY}/${CI_PROJECT_PATH}/cache"
+  KANIKO_PUSH_RETRY: "5"
+
+.build_with_kaniko: &kaniko #Hidden job to use as an "extends" template
+  before_script:
+    - |
+      echo "Build triggered by $CI_PIPELINE_SOURCE"
+      mkdir -p /kaniko/.docker
+      echo "{\"auths\":{\"${CI_REGISTRY}\":{\"auth\":\"$(printf "%s:%s" "${CI_REGISTRY_USER}" "${CI_REGISTRY_PASSWORD}" | base64 | tr -d '\n')\"}}}" > /kaniko/.docker/config.json
+
+  script:
+    - |
+      echo "Building and shipping image to $KANIKO_IMAGE"
+      #Build date for opencontainers
+      BUILDDATE="'$(date '+%FT%T%z' | sed -E -n 's/(\+[0-9]{2})([0-9]{2})$/\1:\2/p')'" #rfc 3339 date
+      IMAGE_LABELS="$KANIKO_IMAGE_LABELS --label org.opencontainers.image.created=$BUILDDATE --label build-date=$BUILDDATE"
+
+      ADDITIONALTAGLIST="$ADDITIONALTAGLIST $KANIKO_TAGS"
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]] && [[ "$KANIKO_IMAGE" == "$CI_REGISTRY_IMAGE" ]]; then ADDITIONALTAGLIST="$ADDITIONALTAGLIST latest"; fi
+      if [[ -n "$ADDITIONALTAGLIST" ]]; then
+        for TAG in $ADDITIONALTAGLIST; do
+          FORMATTEDTAGLIST="${FORMATTEDTAGLIST} --tag $KANIKO_IMAGE:$TAG ";
+        done;
+      fi
+
+      #Reformat Docker tags to kaniko's --destination argument:
+      FORMATTEDTAGLIST=$(echo "${FORMATTEDTAGLIST}" | sed s/\-\-tag/\-\-destination/g)
+    - |
+      echo "Building image with kaniko:"
+      echo "  --context=${KANIKO_CONTEXT}"
+      echo "  --dockerfile=${KANIKO_DOCKERFILE}"
+      echo "  ${KANIKO_ARGS}"
+      echo "  ${FORMATTEDTAGLIST}"
+      echo "  ${IMAGE_LABELS}"
+    - >-
+      HTTP_PROXY=${KANIKO_CACHE_PROXY}
+      NO_PROXY=${KANIKO_CACHE_HOST}
+      /kaniko/executor
+      --context ${KANIKO_CONTEXT}
+      --dockerfile ${KANIKO_DOCKERFILE}
+      ${KANIKO_ARGS}
+      ${FORMATTEDTAGLIST}
+      ${IMAGE_LABELS}
+
+.variables: &variables
+  KANIKO_CONTEXT: "${CI_PROJECT_DIR}"
+  KANIKO_DOCKERFILE: "${CI_PROJECT_DIR}/Dockerfile"
+  KANIKO_IMAGE: $CI_REGISTRY_IMAGE
+  RUNTIME: devel
+  KANIKO_TAGS: $CI_BUILD_REF_SLUG-$PROJECT_VERSION-$RUNTIME-$DISTRO $CI_COMMIT_SHORT_SHA-$PROJECT_VERSION-$RUNTIME-$DISTRO
+  KANIKO_ARGS: >-
+    --cache=true
+    --cache-copy-layers=true
+    --cache-repo=${KANIKO_CACHE_REPO}
+    --cache-ttl=24h
+    --insecure
+    --log-timestamp
+    --push-retry=${KANIKO_PUSH_RETRY}
+    --skip-tls-verify
+    --snapshotMode=redo
+    --reproducible=true
+    --verbosity=${KANIKO_VERBOSITY}
+    --build-arg PROJECT_VERSION=$PROJECT_VERSION
+    --build-arg DISTRO=$DISTRO
+    --build-arg RUNTIME=$RUNTIME
+  KANIKO_IMAGE_LABELS: >-
+    --label org.opencontainers.image.vendor=$CI_SERVER_URL/$CI_PROJECT_NAMESPACE
+    --label org.opencontainers.image.authors=$CI_SERVER_URL/$CI_PROJECT_NAMESPACE
+    --label org.opencontainers.image.revision=$CI_COMMIT_SHA
+    --label org.opencontainers.image.source=$CI_PROJECT_URL
+    --label org.opencontainers.image.documentation=$CI_PROJECT_URL
+    --label org.opencontainers.image.licenses=$CI_PROJECT_URL
+    --label org.opencontainers.image.url=$CI_PROJECT_URL
+    --label vcs-url=$CI_PROJECT_URL
+    --label com.gitlab.ci.user=$CI_SERVER_URL/$GITLAB_USER_LOGIN
+    --label com.gitlab.ci.email=$GITLAB_USER_EMAIL
+    --label com.gitlab.ci.tagorbranch=$CI_BUILD_REF_SLUG
+    --label com.gitlab.ci.pipelineurl=$CI_PIPELINE_URL
+    --label com.gitlab.ci.commiturl=$CI_PROJECT_URL/commit/$CI_COMMIT_SHA
+    --label com.gitlab.ci.cijoburl=$CI_JOB_URL
+    --label com.gitlab.ci.mrurl=$CI_PROJECT_URL/-/merge_requests/$CI_MERGE_REQUEST_ID
 
 stages:
   - build
 
-variables:
-  DOCKER_DRIVER: overlay2
-  CONTAINER_TEST_IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
-  CONTAINER_RELEASE_IMAGE: $CI_REGISTRY_IMAGE:latest
-  TRIVY_IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-
-Kanikoize:
-  tags:
-    - ord1-tenant
+build-samba4.16.1-ubuntu20.04:
+  <<: *kaniko
   stage: build
-  image:
-    name: gcr.io/kaniko-project/executor:debug
-    entrypoint: [""]
-  script:
-    - |
-        mkdir -p /kaniko/.docker
-        echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
-        if [[ -z "$CI_COMMIT_TAG" ]]; then
-          /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile \
-            --destination $CONTAINER_TEST_IMAGE --destination $CONTAINER_RELEASE_IMAGE \
-            --destination $TRIVY_IMAGE
-        else
-          /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile \
-            --destination $CONTAINER_TEST_IMAGE --destination $CONTAINER_RELEASE_IMAGE \
-            --destination $TRIVY_IMAGE --destination "$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG"
-        fi
-  only:
-    variables:
-      - ($CI_COMMIT_BRANCH == "master") || ($CI_COMMIT_TAG != "")
-  needs: []
+  variables:
+    <<: *variables
+    PROJECT_VERSION: "4.16.1"
+    DISTRO: ubuntu20.04


### PR DESCRIPTION
This PR refactors to use a multi-stage Docker build approach. Reduces image size from 900mb+ to ~120mb.

CI has also been refactored to @todie spec. Kaniko cache hits reduces build time from ~30mins to ~2mins when iterating. 