### PR TITLE
feat: Parametrize log level

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ variables:
   KANIKO_CONTEXT: "${CI_PROJECT_DIR}"
   KANIKO_DOCKERFILE: "${CI_PROJECT_DIR}/Dockerfile"
   KANIKO_IMAGE: $CI_REGISTRY_IMAGE
-  KANIKO_TAGS: $CI_BUILD_REF_SLUG-$PROJECT_VERSION-$DISTRO $CI_COMMIT_SHORT_SHA-$PROJECT_VERSION-$DISTRO
+  KANIKO_TAGS: $CI_BUILD_REF_SLUG-$PROJECT_VERSION-$DISTRO_IMAGE-$DISTRO_TAG $CI_COMMIT_SHORT_SHA-$PROJECT_VERSION-$DISTRO_IMAGE-$DISTRO_TAG
   KANIKO_ARGS: >-
     --cache=true
     --cache-copy-layers=true
@@ -82,8 +82,9 @@ variables:
     --snapshotMode=redo
     --reproducible=true
     --verbosity=${KANIKO_VERBOSITY}
-    --build-arg PROJECT_VERSION=$PROJECT_VERSION
-    --build-arg DISTRO=$DISTRO
+    --build-arg PROJECT_VERSION=${PROJECT_VERSION}
+    --build-arg DISTRO_IMAGE=${DISTRO_IMAGE}
+    --build-arg DISTRO_TAG=${DISTRO_TAG}
   KANIKO_IMAGE_LABELS: >-
     --label org.opencontainers.image.vendor=$CI_SERVER_URL/$CI_PROJECT_NAMESPACE
     --label org.opencontainers.image.authors=$CI_SERVER_URL/$CI_PROJECT_NAMESPACE
@@ -105,7 +106,7 @@ stages:
   - build
   - tag
 
-build-samba4.17.0-ubuntu20.04:
+build-samba-ad-ubuntu:
   <<: *kaniko
   stage: build
   rules:
@@ -115,11 +116,11 @@ build-samba4.17.0-ubuntu20.04:
       when: always
   variables:
     <<: *variables
-    PROJECT_VERSION: "4.17.0"
-    DISTRO: ubuntu20.04
+    DISTRO_IMAGE: ubuntu
+    DISTRO_TAG: focal
 
 generate-release-version-tag:
-  needs: [build-samba4.17.0-ubuntu20.04]
+  needs: [build-samba-ad-ubuntu]
   image: node:16
   stage: tag
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ build-samba-ad-ubuntu:
       when: always
   variables:
     <<: *variables
+    PROJECT_VERSION: "4.17.1"
     DISTRO_IMAGE: ubuntu
     DISTRO_TAG: focal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:focal AS builder
+FROM ${DISTRO_IMAGE}:${DISTRO_TAG} AS builder
+
+ARG PROJECT_VERSION=${PROJECT_VERSION}
 
 SHELL ["/bin/bash", "-c"]
 
@@ -101,11 +103,11 @@ RUN apt-get -y update && \
     xsltproc \
     zlib1g-dev
 
-RUN wget https://download.samba.org/pub/samba/stable/samba-4.17.0.tar.gz
+RUN wget https://download.samba.org/pub/samba/stable/samba-${PROJECT_VERSION}.tar.gz
 
-RUN tar -zxf samba-4.17.0.tar.gz
+RUN tar -zxf samba-${PROJECT_VERSION}.tar.gz
 
-WORKDIR /samba-4.17.0
+WORKDIR /samba-${PROJECT_VERSION}
 
 RUN ./configure
 
@@ -119,7 +121,7 @@ ENV PATH=/usr/local/samba/bin/:/usr/local/samba/sbin/:$PATH
 
 WORKDIR /
 
-RUN rm -rf /samba-4.17.0
+RUN rm -rf /samba-${PROJECT_VERSION}
 
 RUN mv -v /usr/local/samba/lib/libnss_win{s,bind}.so.*  /lib
 
@@ -135,7 +137,7 @@ RUN chmod +x /entrypoint.sh
 
 RUN tar -cf artifacts.tar /usr/local/ /etc/samba/ /entrypoint.sh /etc/supervisor/conf.d/supervisord.conf /lib/libnss_win{s,bind}.so.*
 
-FROM ubuntu:focal
+FROM ${DISTRO_IMAGE}:${DISTRO_TAG}
 
 SHELL ["/bin/bash", "-c"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,7 +97,7 @@ cat > /usr/local/samba/etc/smb.conf << EOL
     client min protocol = SMB2_10
     server min protocol = SMB2_10
     smb encrypt = auto
-    log level = 1
+    log level = ${LOG_LEVEL:="1"}
     log file = /dev/stdout
 
     #SMB Multichannel


### PR DESCRIPTION
This PR: 

- Moves Samba and container build versions to the CI file
- Bumps Samba 4.17.0 > 4.17.1
- Allows configuration of `log level` via env var, defaults to old previous of `1` if not provided 