### PR TITLE
feat: Bump to 4.17.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ build-samba-ad-ubuntu:
       when: always
   variables:
     <<: *variables
-    PROJECT_VERSION: "4.17.1"
+    PROJECT_VERSION: "4.17.2"
     DISTRO_IMAGE: ubuntu
     DISTRO_TAG: focal
 


### PR DESCRIPTION
Includes CVE patches: https://www.samba.org/samba/history/samba-4.17.2.html