### PR TITLE
feat: Bump to 4.17.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ build-samba-ad-ubuntu:
       when: always
   variables:
     <<: *variables
-    PROJECT_VERSION: "4.17.2"
+    PROJECT_VERSION: "4.17.3"
     DISTRO_IMAGE: ubuntu
     DISTRO_TAG: focal
 


### PR DESCRIPTION
CVE Patch: https://www.samba.org/samba/security/CVE-2022-42898.html